### PR TITLE
Implement generic argument impls

### DIFF
--- a/crates/hir-ty/src/next_solver.rs
+++ b/crates/hir-ty/src/next_solver.rs
@@ -3,6 +3,7 @@ mod interner;
 mod abi;
 mod consts;
 mod generic_arg;
+mod generics;
 mod infer;
 mod ir_print;
 mod lifetime;
@@ -20,6 +21,7 @@ type Symbol = ();
 pub use abi::Safety;
 pub use consts::{Const, ExprConst, ParamConst, PlaceholderConst, UnevaluatedConst, ValueConst};
 pub use generic_arg::{GenericArg, GenericArgs, GenericArgsSlice, Term};
+pub use generics::Generics;
 pub use infer::{Canonical, CanonicalVarInfo, CanonicalVarValues};
 pub use interner::*;
 pub use lifetime::{

--- a/crates/hir-ty/src/next_solver/consts.rs
+++ b/crates/hir-ty/src/next_solver/consts.rs
@@ -50,6 +50,14 @@ impl rustc_type_ir::inherent::BoundVarLike<DbInterner> for BoundConst {
     }
 }
 
+impl Const {
+    pub fn error() -> Self {
+        with_db_out_of_thin_air(|db| {
+            db.intern_rustc_const(InternedConst(ConstKind::Error(ErrorGuaranteed)))
+        })
+    }
+}
+
 impl IntoKind for Const {
     type Kind = ConstKind;
 

--- a/crates/hir-ty/src/next_solver/generics.rs
+++ b/crates/hir-ty/src/next_solver/generics.rs
@@ -1,0 +1,41 @@
+use super::{DbInterner, DefId, GenericArg};
+
+#[derive(Debug)]
+pub struct Generics {
+    pub parent: Option<DefId>,
+
+    pub own_params: Vec<GenericParamDef>,
+}
+
+#[derive(Debug)]
+pub struct GenericParamDef {
+    pub def_id: DefId,
+    pub index: u32,
+
+    pub kind: GenericParamDefKind,
+}
+
+#[derive(Debug)]
+pub enum GenericParamDefKind {
+    Lifetime,
+    Type,
+    Const,
+}
+
+impl rustc_type_ir::inherent::GenericsOf<DbInterner> for Generics {
+    fn count(&self) -> usize {
+        todo!()
+    }
+}
+
+impl GenericParamDef {
+    pub fn to_error(&self, interner: DbInterner) -> GenericArg {
+        todo!()
+    }
+}
+
+impl DbInterner {
+    pub fn mk_param_from_def(self, param: &GenericParamDef) -> GenericArg {
+        todo!()
+    }
+}

--- a/crates/hir-ty/src/next_solver/interner.rs
+++ b/crates/hir-ty/src/next_solver/interner.rs
@@ -14,6 +14,7 @@ use crate::{db::HirDatabase, FnAbi};
 use super::{
     consts::{BoundConst, InternedConst},
     generic_arg::InternedGenericArgs,
+    generics::Generics,
     opaques::{InternedDefiningOpaqueTypes, InternedExternalConstraints},
     predicate::{InternedBoundExistentialPredicates, InternedClauses, InternedPredicate},
     ty::{InternedTy, InternedTys},
@@ -30,6 +31,10 @@ macro_rules! interned_vec {
             #[derive(Debug, Clone, PartialEq, Eq, Hash)]
             pub struct [<Interned $name>](Vec<$ty>);
             impl base_db::salsa::InternValueTrivial for [<Interned $name>] {}
+            impl std::ops::Deref for [<Interned $name>] {
+                type Target = Vec<$ty>;
+                fn deref(&self) -> &Self::Target { &self.0 }
+            }
 
             #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
             pub struct $name(base_db::salsa::InternId);
@@ -714,8 +719,6 @@ pub struct Placeholder<T> {
 
 pub(crate) type DebruijnIndex = u32;
 
-pub struct Generics;
-
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
 pub struct AdtDef(hir_def::AdtId);
 
@@ -794,12 +797,6 @@ impl Relate<DbInterner> for PatId {
         a: Self,
         b: Self,
     ) -> rustc_type_ir::relate::RelateResult<DbInterner, Self> {
-        todo!()
-    }
-}
-
-impl rustc_type_ir::inherent::GenericsOf<DbInterner> for Generics {
-    fn count(&self) -> usize {
         todo!()
     }
 }

--- a/crates/hir-ty/src/next_solver/lifetime.rs
+++ b/crates/hir-ty/src/next_solver/lifetime.rs
@@ -6,7 +6,7 @@ use rustc_type_ir::{
     BoundVar, RegionKind, TypeFlags, INNERMOST,
 };
 
-use super::{BoundVarKind, DbInterner, DefId, Placeholder, Symbol};
+use super::{BoundVarKind, DbInterner, DefId, ErrorGuaranteed, Placeholder, Symbol};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub struct Region {
@@ -196,6 +196,10 @@ impl rustc_type_ir::inherent::Region<DbInterner> for Region {
 }
 
 impl Region {
+    pub fn error() -> Self {
+        Self { kind: RegionKind::ReError(ErrorGuaranteed) }
+    }
+
     pub fn type_flags(&self) -> TypeFlags {
         let mut flags = TypeFlags::empty();
 

--- a/crates/hir-ty/src/next_solver/ty.rs
+++ b/crates/hir-ty/src/next_solver/ty.rs
@@ -39,6 +39,12 @@ pub enum BoundTyKind {
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub struct ErrorGuaranteed;
 
+impl Ty {
+    pub fn error() -> Self {
+        with_db_out_of_thin_air(|db| db.intern_rustc_ty(InternedTy(TyKind::Error(ErrorGuaranteed))))
+    }
+}
+
 impl IntoKind for Ty {
     type Kind = TyKind<DbInterner>;
 


### PR DESCRIPTION
Some `todo!` are left, which should be filled at later time when we have more info related to generics args much of what is in rustc is still left. So I'm keeping it `todo!` for now.